### PR TITLE
Add WebAssembly extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.5
+
+* Add support for the WebAssembly format.
+
 # 0.9.4
 
 * Updated Dart SDK requirement to `>= 1.8.3 <2.0.0`

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -883,6 +883,7 @@ final Map<String, String> defaultExtensionMap = <String, String>{
   'vxml': 'application/voicexml+xml',
   'w3d': 'application/x-director',
   'wad': 'application/x-doom',
+  'wasm': 'application/wasm',
   'wav': 'audio/x-wav',
   'wax': 'audio/x-ms-wax',
   'wbmp': 'image/vnd.wap.wbmp',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mime
-version: 0.9.4
+version: 0.9.5
 author: Dart Team <misc@dartlang.org>
 description: Helper-package for working with MIME.
 homepage: https://www.github.com/dart-lang/mime


### PR DESCRIPTION
WebAssembly files (`.wasm`) need to be served with the correct MIME type (see more info [here](http://webassembly.org/docs/web/#additional-web-embedding-api)) in order to run properly in the browser.

Since Pub uses this package to determine MIME types, `pub serve` can't be used out of the box for developing a Dart project that includes WebAssembly assets.