### PR TITLE
change the mime type for dart source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
+# 0.9.6+2
+
+* Change the mime type for Dart source from `application/dart` to `text/x-dart`.
+
 # 0.9.6+1
 
-- Stop using deprecated constants from the SDK.
+* Stop using deprecated constants from the SDK.
 
 # 0.9.6
 
 * Updates to support Dart 2.0 core library changes (wave
   2.2). See [issue 31847][sdk#31847] for details.
-  
+
   [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
 
 # 0.9.5

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -150,7 +150,7 @@ final Map<String, String> defaultExtensionMap = <String, String>{
   'cxx': 'text/x-c',
   'dae': 'model/vnd.collada+xml',
   'daf': 'application/vnd.mobius.daf',
-  'dart': 'application/dart',
+  'dart': 'text/x-dart',
   'dataless': 'application/vnd.fdsn.seed',
   'davmount': 'application/davmount+xml',
   'dbk': 'application/docbook+xml',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mime
-version: 0.9.6+1
+version: 0.9.6+2
 author: Dart Team <misc@dartlang.org>
 description: Helper-package for working with MIME.
 homepage: https://www.github.com/dart-lang/mime

--- a/test/mime_type_test.dart
+++ b/test/mime_type_test.dart
@@ -23,9 +23,9 @@ void _expectMimeType(String path, String expectedMimeType,
 void main() {
   group('global-lookup', () {
     test('by-path', () {
-      _expectMimeType('file.dart', 'application/dart');
+      _expectMimeType('file.dart', 'text/x-dart');
       // Test mixed-case
-      _expectMimeType('file.DaRT', 'application/dart');
+      _expectMimeType('file.DaRT', 'text/x-dart');
       _expectMimeType('file.html', 'text/html');
       _expectMimeType('file.xhtml', 'application/xhtml+xml');
       _expectMimeType('file.jpeg', 'image/jpeg');


### PR DESCRIPTION
Change the mime type for Dart source from `application/dart` to `text/x-dart`.

When working on a server serving up a browser based directory listing, I noticed that Dart source files were not displayed by the browser, but instead popped up a dialog asking to save them as binary content. Other source files (css, html, ...) were instead displayed in the browser.

The server was reporting `application/dart` as the mime type for Dart files. The `application/` prefix is an indication to the browser that the file has binary content; as the browser didn't understand that binary format, it didn't attempt to display it.

Previously we had native processors of Dart files (and the `application/dart` mime type) - Dartium; however executable Dart on the web now just exists in the form of compiled JS files.

I think we should change the default mime type of Dart files to something that browsers will recognize as text based. From a quick perusal of other languages (and reading https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), this would be something like `text/x-dart`.

@kevmoo @anders-sandholm 
