### PR TITLE
Bug fix: emit error during parsing

### DIFF
--- a/lib/src/bound_multipart_stream.dart
+++ b/lib/src/bound_multipart_stream.dart
@@ -133,7 +133,11 @@ class BoundMultipartStream {
             _subscription.pause();
             _buffer = data;
             _index = 0;
-            _parse();
+            try {
+              _parse();
+            } catch (e, st) {
+              _controller.addError(e, st);
+            }
           }, onDone: () {
             if (_state != _DONE) {
               _controller

--- a/lib/src/bound_multipart_stream.dart
+++ b/lib/src/bound_multipart_stream.dart
@@ -136,10 +136,11 @@ class BoundMultipartStream {
             try {
               _parse();
             } catch (e, st) {
+              _state = _FAIL;
               _controller.addError(e, st);
             }
           }, onDone: () {
-            if (_state != _DONE) {
+            if (_state != _DONE && _state != _FAIL) {
               _controller
                   .addError(new MimeMultipartException("Bad multipart ending"));
             }

--- a/lib/src/bound_multipart_stream.dart
+++ b/lib/src/bound_multipart_stream.dart
@@ -140,12 +140,12 @@ class BoundMultipartStream {
               _controller.addError(e, st);
             }
           }, onDone: () {
-            if (_state != _DONE && _state != _FAIL) {
+            if (_state != _DONE) {
               _controller
                   .addError(new MimeMultipartException("Bad multipart ending"));
             }
             _controller.close();
-          }, onError: _controller.addError);
+          }, onError: _controller.addError, cancelOnError: true);
         });
   }
 

--- a/test/async_parse_test.dart
+++ b/test/async_parse_test.dart
@@ -4,24 +4,118 @@ import 'package:mime/mime.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("error is emitted from stream during parse ", () async {
-    final input = """
---xxxh\r
-Content-Disposition: form-data; name="a"\r
-Content-Type: application/json; charset=utf-8',\r
-[\r
-{"key": "value1"}]\r
---xxx--\r\n
-"""
-        .codeUnits;
+  test("Can parse valid data in chunks", () async {
+    final controller = StreamController<List<int>>();
+    final transformedStream =
+        controller.stream.transform(MimeMultipartTransformer("xxx"));
+    controller.add(_goodData.sublist(0, 10));
+
+    // push the chunk to the next event
+    Future(() {
+      controller.add(_goodData.sublist(10));
+      controller.close();
+    });
+
+    final parts = await transformedStream.toList();
+    expect(parts.length, 2);
+  });
+
+  test(
+      "If parsing fails on first part, error is emitted from stream and no further parts are parsed",
+      () async {
+    final controller = StreamController<List<int>>();
+    final transformedStream =
+        controller.stream.transform(MimeMultipartTransformer("xxx"));
+    controller.add(_malformedFirstPart.sublist(0, 10));
+
+    // push the chunk to the next event
+    Future(() {
+      controller.add(_malformedFirstPart.sublist(10));
+      controller.close();
+    });
 
     try {
-      final controller = Stream.fromIterable([input])
-          .transform(MimeMultipartTransformer("xxx"));
-      await controller.toList();
+      await transformedStream.toList();
       fail('unreachable');
     } on MimeMultipartException catch (e) {
       expect(e.message, contains("Failed to parse"));
     }
+
+    expect(controller.done, completes);
+  });
+
+  test(
+      "If parsing fails on 2nd part, error is emitted from stream after receiving first part",
+      () async {
+    final controller = StreamController<List<int>>();
+    final transformedStream =
+        controller.stream.transform(MimeMultipartTransformer("xxx"));
+    controller.add(_malformedSecondPart.sublist(0, 10));
+
+    // push the chunk to the next event
+    Future(() {
+      controller.add(_malformedSecondPart.sublist(10));
+      controller.close();
+    });
+
+    final parts = <MimeMultipart>[];
+    var error;
+    transformedStream.listen((part) {
+      parts.add(part);
+    }, onError: (e, st) {
+      error = e;
+    });
+
+    await controller.done;
+    expect(parts.length, 1);
+    expect(error.toString(), contains("MimeMultipartException"));
   });
 }
+
+// Invalid header for 1st part
+final _malformedFirstPart = """
+--xxx\r
+Content-Disposition: form-data; name="a"\r
+Content-Type: application/json; charset=invalid'\r
+\r
+[\r
+{"key": "value1"}]\r
+--xxx\r 
+Content-Disposition: form-data; name="b"\r
+\r 
+xyhz\r
+--xxx--\r
+"""
+    .codeUnits;
+
+// Missing content from 2nd part
+final _malformedSecondPart = """
+--xxx\r
+Content-Disposition: form-data; name="a"\r
+Content-Type: application/json; charset=utf-8\r
+\r
+[\r
+{"key": "value1"}]\r
+--xxx\r 
+Content-Disposition: form-data; name="b"'\r
+\r
+foobar\r
+--xxx--\r
+"""
+    .codeUnits;
+
+// Correctly formed, 2 part data
+final _goodData = """
+--xxx\r
+Content-Disposition: form-data; name="a"\r
+Content-Type: application/json; charset=utf-8\r
+\r
+[{"key": "value1"}]\r
+--xxx\r
+Content-Disposition: form-data; name="a"\r
+Content-Type: text/plain\r
+\r
+text\r
+--xxx--\r
+"""
+    .codeUnits;

--- a/test/async_parse_test.dart
+++ b/test/async_parse_test.dart
@@ -52,18 +52,18 @@ void main() {
         controller.stream.transform(MimeMultipartTransformer("xxx"));
     controller.add(_malformedSecondPart.sublist(0, 10));
 
-    // push the chunk to the next event
-    Future(() {
-      controller.add(_malformedSecondPart.sublist(10));
-      controller.close();
-    });
-
     final parts = <MimeMultipart>[];
     var error;
     transformedStream.listen((part) {
       parts.add(part);
     }, onError: (e, st) {
       error = e;
+    });
+
+    // push the chunk to the next event
+    Future(() {
+      controller.add(_malformedSecondPart.sublist(10));
+      controller.close();
     });
 
     await controller.done;

--- a/test/async_parse_test.dart
+++ b/test/async_parse_test.dart
@@ -12,10 +12,12 @@ Content-Type: application/json; charset=utf-8',\r
 [\r
 {"key": "value1"}]\r
 --xxx--\r\n
-""".codeUnits;
+"""
+        .codeUnits;
 
     try {
-      final controller = Stream.fromIterable([input]).transform(MimeMultipartTransformer("xxx"));
+      final controller = Stream.fromIterable([input])
+          .transform(MimeMultipartTransformer("xxx"));
       await controller.toList();
       fail('unreachable');
     } on MimeMultipartException catch (e) {

--- a/test/async_parse_test.dart
+++ b/test/async_parse_test.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+
+import 'package:mime/mime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test("error is emitted from stream during parse ", () async {
+    final input = """
+--xxxh\r
+Content-Disposition: form-data; name="a"\r
+Content-Type: application/json; charset=utf-8',\r
+[\r
+{"key": "value1"}]\r
+--xxx--\r\n
+""".codeUnits;
+
+    try {
+      final controller = Stream.fromIterable([input]).transform(MimeMultipartTransformer("xxx"));
+      await controller.toList();
+      fail('unreachable');
+    } on MimeMultipartException catch (e) {
+      expect(e.message, contains("Failed to parse"));
+    }
+  });
+}


### PR DESCRIPTION
When the following two criteria are true:

- `MimeMultipartTransformer` is bound to an async stream 
- input data is invalid such that `_parse()` fails prior to all bytes being read

There is no way to catch the parse error and it will always go uncaught. The current test suite uses a synchronous stream for testing and does not cover transforming asynchronous streams. The test added by this PR will fail without the code change. I am struggling to understand why the error isn't propagated in the first place, so if there is a better way, I'm all for it. 

This blocks https://github.com/stablekernel/aqueduct/issues/315.