### PR TITLE
Support for m4a mime type

### DIFF
--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -418,6 +418,7 @@ final Map<String, String> defaultExtensionMap = <String, String>{
   'm3u8': 'application/vnd.apple.mpegurl',
   'm4u': 'video/vnd.mpegurl',
   'm4v': 'video/x-m4v',
+  'm4a': 'audio/mp4', // audio/x-m4a is NOT a valid mime type (https://www.iana.org/assignments/media-types/media-types.xhtml) (Discussion: https://github.com/Sigil-Ebook/Sigil/issues/198)
   'ma': 'application/mathematica',
   'mads': 'application/mads+xml',
   'mag': 'application/vnd.ecowin.chart',


### PR DESCRIPTION
m4a mime type is proprietary to iOS. Looking at other [discussions](https://github.com/Sigil-Ebook/Sigil/issues/198), `audio/x-m4a` is not a valid mime type and is not on the [official mime registration list](https://www.iana.org/assignments/media-types/media-types.xhtml).

So `m4a` has a legitimate mime type of `audio/mp4`