### PR TITLE
Remove unneeded dart:async import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-- 2.0.0
+- 2.1.0
 - dev
 
 dart_task:

--- a/lib/src/mime_shared.dart
+++ b/lib/src/mime_shared.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 library mime.shared;
 
-import 'dart:async';
-
 class MimeMultipartException implements Exception {
   final String message;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 homepage: https://github.com/dart-lang/mime
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.0.0


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core.

Alternatively, if for some reason this package needs to continue to
support Dart 2.0, an exception can be made for this internally.