### PR TITLE
Add woff2 mime type

### DIFF
--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -909,6 +909,7 @@ const Map<String, String> defaultExtensionMap = <String, String>{
   'wmx': 'video/x-ms-wmx',
   'wmz': 'application/x-ms-wmz',
   'woff': 'application/x-font-woff',
+  'woff2': 'font/woff2',
   'wpd': 'application/vnd.wordperfect',
   'wpl': 'application/vnd.ms-wpl',
   'wps': 'application/vnd.ms-works',

--- a/lib/src/magic_number.dart
+++ b/lib/src/magic_number.dart
@@ -65,4 +65,5 @@ const List<MagicNumber> DEFAULT_MAGIC_NUMBERS = [
     0xFF
   ]),
   MagicNumber('model/gltf-binary', [0x46, 0x54, 0x6C, 0x67]),
+  MagicNumber('font/woff2', [0x77, 0x4f, 0x46, 0x32]),
 ];


### PR DESCRIPTION
Adds an entry for `font/woff2`, a font format.

Sources:

- the media type is registered [here](https://www.w3.org/TR/WOFF2/#IMT)
- the header bytes are specified [here](https://www.w3.org/TR/WOFF2/#woff20Header)