### PR TITLE
Add `audio/m4p` mimeType lookup by file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
-# 1.0.3
-
-* Add `audio/m4a` mimeType lookup by file path.
-
 # 1.0.2
 
 * Add audio/x-aiff mimeType lookup by header bytes.
 * Add audio/x-flac mimeType lookup by header bytes.
 * Add audio/x-wav mimeType lookup by header bytes.
+* Add audio/m4a mimeType lookup by file path.
 
 # 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+* Add `audio/m4a` mimeType lookup by file path.
+
 # 1.0.2
 
 * Add audio/x-aiff mimeType lookup by header bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Add audio/x-aiff mimeType lookup by header bytes.
 * Add audio/x-flac mimeType lookup by header bytes.
 * Add audio/x-wav mimeType lookup by header bytes.
-* Add audio/m4a mimeType lookup by file path.
+* Add audio/mp4 mimeType lookup by file path.
 
 # 1.0.1
 

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -413,6 +413,7 @@ const Map<String, String> defaultExtensionMap = <String, String>{
   'm3a': 'audio/mpeg',
   'm3u': 'audio/x-mpegurl',
   'm3u8': 'application/vnd.apple.mpegurl',
+  'm4a': 'audio/m4a',
   'm4u': 'video/vnd.mpegurl',
   'm4v': 'video/x-m4v',
   'ma': 'application/mathematica',

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -413,6 +413,7 @@ const Map<String, String> defaultExtensionMap = <String, String>{
   'm3a': 'audio/mpeg',
   'm3u': 'audio/x-mpegurl',
   'm3u8': 'application/vnd.apple.mpegurl',
+  // Source: https://www.rfc-editor.org/rfc/rfc4337#page-3
   'm4a': 'audio/mp4',
   'm4u': 'video/vnd.mpegurl',
   'm4v': 'video/x-m4v',

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -413,7 +413,7 @@ const Map<String, String> defaultExtensionMap = <String, String>{
   'm3a': 'audio/mpeg',
   'm3u': 'audio/x-mpegurl',
   'm3u8': 'application/vnd.apple.mpegurl',
-  'm4a': 'audio/m4a',
+  'm4a': 'audio/mp4',
   'm4u': 'video/vnd.mpegurl',
   'm4v': 'video/x-m4v',
   'ma': 'application/mathematica',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mime
-version: 1.0.2
+version: 1.0.3
 
 description: >-
   Utilities for handling media (MIME) types, including determining a type from

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mime
-version: 1.0.3
+version: 1.0.2
 
 description: >-
   Utilities for handling media (MIME) types, including determining a type from

--- a/test/mime_type_test.dart
+++ b/test/mime_type_test.dart
@@ -42,7 +42,7 @@ void main() {
       _expectMimeType('file.tif', 'image/tiff');
       _expectMimeType('file.webp', 'image/webp');
       _expectMimeType('file.aiff', 'audio/x-aiff');
-      _expectMimeType('file.m4a', 'audio/m4a');
+      _expectMimeType('file.m4a', 'audio/mp4');
     });
 
     test('unknown-mime-type', () {

--- a/test/mime_type_test.dart
+++ b/test/mime_type_test.dart
@@ -42,6 +42,7 @@ void main() {
       _expectMimeType('file.tif', 'image/tiff');
       _expectMimeType('file.webp', 'image/webp');
       _expectMimeType('file.aiff', 'audio/x-aiff');
+      _expectMimeType('file.m4a', 'audio/m4a');
     });
 
     test('unknown-mime-type', () {


### PR DESCRIPTION
Regarding http://help.dottoro.com/lapuadlp.php has the file extension `.m4a` the mime type `audio/m4a`.

I added an `expect` to `by-path`, updated `version` and `CHANGELOG`.

This PR is an improved version of https://github.com/dart-lang/mime/pull/28.