### PR TITLE
Add .avif to extension map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+* Add image/avif mimeType lookup by extension.
+
 # 1.0.2
 
 * Add audio/x-aiff mimeType lookup by header bytes.

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -48,6 +48,7 @@ const Map<String, String> defaultExtensionMap = <String, String>{
   'atx': 'application/vnd.antix.game-component',
   'au': 'audio/basic',
   'avi': 'video/x-msvideo',
+  'avif': 'image/avif',
   'aw': 'application/applixware',
   'azf': 'application/vnd.airzip.filesecure.azf',
   'azs': 'application/vnd.airzip.filesecure.azs',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mime
-version: 1.0.2
+version: 1.0.3
 description: >-
   Utilities for handling media (MIME) types, including determining a type from
   a file extension and file contents.


### PR DESCRIPTION
Quote from https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types


AVIF | AV1 Image File Format | image/avif | .avif | Good choice for both images and animated images due to high performance and royalty free image format. It offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency, etc. Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <picture> element).Supported: Chrome, Opera, Firefox (still images only: animated images not implemented).
-- | -- | -- | -- | --
