### PR TITLE
Add m4b mime type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .pub/
 packages
 pubspec.lock
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .pub/
 packages
 pubspec.lock
-build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.5
+
+* Add m4b mimeType lookup by extension. 
+
 # 1.0.4
 
 * Changed `.js` to `text/javascript` per 

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -419,6 +419,7 @@ const Map<String, String> defaultExtensionMap = <String, String>{
   'm3u8': 'application/vnd.apple.mpegurl',
   // Source: https://www.rfc-editor.org/rfc/rfc4337#page-3
   'm4a': 'audio/mp4',
+  'm4b': 'audio/mp4',
   'm4u': 'video/vnd.mpegurl',
   'm4v': 'video/x-m4v',
   'ma': 'application/mathematica',

--- a/lib/src/default_extension_map.dart
+++ b/lib/src/default_extension_map.dart
@@ -417,7 +417,7 @@ const Map<String, String> defaultExtensionMap = <String, String>{
   'm3a': 'audio/mpeg',
   'm3u': 'audio/x-mpegurl',
   'm3u8': 'application/vnd.apple.mpegurl',
-  // Source: https://www.rfc-editor.org/rfc/rfc4337#page-3
+  // Source: https://datatracker.ietf.org/doc/html/rfc4337#section-2
   'm4a': 'audio/mp4',
   'm4b': 'audio/mp4',
   'm4u': 'video/vnd.mpegurl',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mime
-version: 1.0.4
+version: 1.0.5
 description: >-
   Utilities for handling media (MIME) types, including determining a type from
   a file extension and file contents.

--- a/test/mime_type_test.dart
+++ b/test/mime_type_test.dart
@@ -48,6 +48,7 @@ void main() {
       _expectMimeType('file.ogg', 'audio/ogg');
       _expectMimeType('file.aiff', 'audio/x-aiff');
       _expectMimeType('file.m4a', 'audio/mp4');
+      _expectMimeType('file.m4b', 'audio/mp4');
       _expectMimeType('file.toml', 'application/toml');
     });
 


### PR DESCRIPTION
Currently, there is no mime type support for `.m4b` files (audiobooks). 

This PR maps the m4b extension to the `audio/mp4` mime type - same as m4a files.