### PR TITLE
Detect HEIC/HEIF format by checking header bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.0.5-wip
 
 * Update video/mp4 mimeType lookup by header bytes.
+* Add image/heic mimeType lookup by header bytes.
+* Add image/heif mimeType lookup by header bytes.
 * Add m4b mimeType lookup by extension.
 * Add `text/markdown` mimeType lookup by extension.
 * Require Dart 3.0.0.

--- a/lib/src/magic_number.dart
+++ b/lib/src/magic_number.dart
@@ -309,4 +309,99 @@ const List<MagicNumber> initialMagicNumbers = [
   ]),
 
   MagicNumber('font/woff2', [0x77, 0x4f, 0x46, 0x32]),
+
+  /// High Efficiency Image File Format (ISO/IEC 23008-12).
+  /// -> 4 bytes indicating the ftyp box length.
+  /// -> 4 bytes have the ASCII characters 'f' 't' 'y' 'p'.
+  /// -> 4 bytes have the ASCII characters 'h' 'e' 'i' 'c'.
+  /// https://www.iana.org/assignments/media-types/image/heic
+  MagicNumber('image/heic', [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x66,
+    0x74,
+    0x79,
+    0x70,
+    0x68,
+    0x65,
+    0x69,
+    0x63
+  ], mask: [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF
+  ]),
+
+  /// -> 4 bytes indicating the ftyp box length.
+  /// -> 4 bytes have the ASCII characters 'f' 't' 'y' 'p'.
+  /// -> 4 bytes have the ASCII characters 'h' 'e' 'i' 'x'.
+  MagicNumber('image/heic', [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x66,
+    0x74,
+    0x79,
+    0x70,
+    0x68,
+    0x65,
+    0x69,
+    0x78
+  ], mask: [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF
+  ]),
+
+  /// -> 4 bytes indicating the ftyp box length.
+  /// -> 4 bytes have the ASCII characters 'f' 't' 'y' 'p'.
+  /// -> 4 bytes have the ASCII characters 'm' 'i' 'f' '1'.
+  MagicNumber('image/heif', [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x66,
+    0x74,
+    0x79,
+    0x70,
+    0x6D,
+    0x69,
+    0x66,
+    0x31
+  ], mask: [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF
+  ]),
 ];

--- a/test/mime_type_test.dart
+++ b/test/mime_type_test.dart
@@ -52,6 +52,8 @@ void main() {
       _expectMimeType('file.toml', 'application/toml');
       _expectMimeType('file.md', 'text/markdown');
       _expectMimeType('file.markdown', 'text/markdown');
+      _expectMimeType('file.heif', 'image/heif');
+      _expectMimeType('file.heic', 'image/heic');
     });
 
     test('unknown-mime-type', () {
@@ -232,6 +234,51 @@ void main() {
         0x41,
         0x56,
         0x45
+      ]);
+      _expectMimeType('file', 'image/heic', headerBytes: [
+        0x00,
+        0x00,
+        0x00,
+        0x18,
+        0x66,
+        0x74,
+        0x79,
+        0x70,
+        0x68,
+        0x65,
+        0x69,
+        0x63,
+        0x00
+      ]);
+      _expectMimeType('file', 'image/heic', headerBytes: [
+        0x00,
+        0x00,
+        0x00,
+        0x18,
+        0x66,
+        0x74,
+        0x79,
+        0x70,
+        0x68,
+        0x65,
+        0x69,
+        0x78,
+        0x00
+      ]);
+      _expectMimeType('file', 'image/heif', headerBytes: [
+        0x00,
+        0x00,
+        0x00,
+        0x18,
+        0x66,
+        0x74,
+        0x79,
+        0x70,
+        0x6D,
+        0x69,
+        0x66,
+        0x31,
+        0x00
       ]);
     });
   });


### PR DESCRIPTION
Hi, thank you to this useful package and its maintainers 🙌 

HEIC/HEIF format is already supported in #58, but I want to enhance this detection by checking the header bytes. I have referred to the following documents.

- https://www.loc.gov/preservation/digital/formats/fdd/fdd000526.shtml
- https://www.iana.org/assignments/media-types/image/heic
- https://nokiatech.github.io/heif/technical.html

The header bytes look like this:

- `image/heif`
  - `0x0, 0x0, 0x0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x69, 0x66, 0x31, 0x0, ...`
  - `... f, t, y, p, m, i, f, 1 ...`
- `image/heic`
  - `0x0, 0x0, 0x0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63, 0x0, ...`
  - `... f, t, y, p, h, e, i, c ...`

Also, with this and #58, I think #31 can be closed.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
