### PR TITLE
add support for image/avif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update video/mp4 mimeType lookup by header bytes.
 * Add image/heic mimeType lookup by header bytes.
 * Add image/heif mimeType lookup by header bytes.
+* Add image/avif mimeType lookup by header bytes.
 * Add m4b mimeType lookup by extension.
 * Add `text/markdown` mimeType lookup by extension.
 * Require Dart 3.0.0.

--- a/lib/src/magic_number.dart
+++ b/lib/src/magic_number.dart
@@ -275,6 +275,38 @@ const List<MagicNumber> initialMagicNumbers = [
   ]),
   MagicNumber('model/gltf-binary', [0x46, 0x54, 0x6C, 0x67]),
 
+  /// AVIF format identification
+  /// -> 4 bytes indicating the ftyp box length.
+  /// -> 4 bytes have the ASCII characters 'f' 't' 'y' 'p'.
+  /// -> 4 bytes have the ASCII characters 'a' 'v' 'i' 'f'.
+  MagicNumber('image/avif', [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x66,
+    0x74,
+    0x79,
+    0x70,
+    0x61,
+    0x76,
+    0x69,
+    0x66
+  ], mask: [
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFF
+  ]),
+
   /// The WebP file format is based on the RIFF document format.
   /// -> 4 bytes have the ASCII characters 'R' 'I' 'F' 'F'.
   /// -> 4 bytes indicating the size of the file

--- a/test/mime_type_test.dart
+++ b/test/mime_type_test.dart
@@ -75,6 +75,20 @@ void main() {
         0x1A,
         0x0A
       ]);
+      _expectMimeType('file.avif', 'image/avif', headerBytes: [
+        0x00,
+        0x00,
+        0x00,
+        0x20,
+        0x66,
+        0x74,
+        0x79,
+        0x70,
+        0x61,
+        0x76,
+        0x69,
+        0x66
+      ]);
       _expectMimeType('file.gif', 'image/jpeg', headerBytes: [
         0xFF,
         0xD8,


### PR DESCRIPTION
Added support for mime type 'image/avif'. Code was generated by chatgpt, but it's matching this: https://stackoverflow.com/a/68322450 and i verified it against two avif images  (confirmed mime type of them with `file --mime-type`)

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
