### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,10 @@ description: >-
   Utilities for handling media (MIME) types, including determining a type from
   a file extension and file contents.
 repository: https://github.com/dart-lang/mime
+topics:
+ - mimetype
+ - magic-numbers
+ - multipart-form
 
 environment:
   sdk: ^3.2.0


### PR DESCRIPTION
Topics helps users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to `pubspec.yaml` as follows:

```yaml
topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics