### PR TITLE
blast repo changes: dependabot, github-actions, no-response

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,7 @@ updates:
       interval: monthly
     labels:
       - autosubmit
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,7 +21,7 @@ jobs:
       # These are the latest versions of the github actions; dependabot will
       # send PRs to keep these up-to-date.
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+      - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
This PR contains changes created by the blast repo tool.

- `dependabot`
- `github-actions`
- `no-response`